### PR TITLE
added .flush methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 var fs = require('fs')
 var generateTempFilePath = require('tempfile2')
 
+function emitError(err) {
+	writeStream.emit('error', err)
+}
+
 module.exports = function createTempFile(params) {
 	var path = generateTempFilePath(params)
 	var writeStream = fs.createWriteStream(path)
@@ -15,9 +19,16 @@ module.exports = function createTempFile(params) {
 			emitError(err)
 		}
 	}
-	return writeStream
 
-	function emitError(err) {
-		writeStream.emit('error', err)
+	writeStream.flush = function fls() {
+		fileStream.end();
+		return writeStream.cleanup();
 	}
+
+	writeStream.flushSync = function flsSnc() {
+		fileStream.end();
+		return writeStream.cleanupSync();
+	}
+
+	return writeStream
 }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,20 @@
 var fs = require('fs')
 var generateTempFilePath = require('tempfile2')
 
-function emitError(err) {
-	writeStream.emit('error', err)
-}
-
 module.exports = function createTempFile(params) {
 	var path = generateTempFilePath(params)
 	var writeStream = fs.createWriteStream(path)
+
+	function emitError(err) {
+		writeStream.emit('error', err)
+	}
+
 	writeStream.path = path
+
 	writeStream.cleanup = function cln(cb) {
 		fs.unlink(path, cb || emitError)
 	}
+
 	writeStream.cleanupSync = function clnSnc() {
 		try {
 			fs.unlinkSync(path)

--- a/index.js
+++ b/index.js
@@ -24,12 +24,12 @@ module.exports = function createTempFile(params) {
 	}
 
 	writeStream.flush = function fls() {
-		fileStream.end();
+		writeStream.end();
 		return writeStream.cleanup();
 	}
 
 	writeStream.flushSync = function flsSnc() {
-		fileStream.end();
+		writeStream.end();
 		return writeStream.cleanupSync();
 	}
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "tap": "^1.0.10"
   },
   "dependencies": {
+    "end-of-stream": "~1.1.0",
     "tempfile2": "^1.0.0"
   }
 }


### PR DESCRIPTION
When I'm working with this library and if I need to delete the stream/file under mi application architecture error I have something like:

``` js
var streamError = function(fileStream) {
  fileStream.end();
  fileStream.cleanupSync();
};
```

this function flush the data of the stream, close the descriptor file and remove the file. Can be useful to integrate in the library to be invoke using the library keyword.
