### PR TITLE
improvements

### DIFF
--- a/.bumpedrc
+++ b/.bumpedrc
@@ -1,0 +1,6 @@
+files: [
+  "package.json"
+]
+plugins:
+  prerelease: []
+  postrelease: []

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
-var generateTempFilePath = require('tempfile2')
 var streamEnd = require('end-of-stream')
+var generateTempFilePath = require('tempfile2')
 
 module.exports = function createTempFile(params) {
 	var streamHasEnded = false
@@ -13,17 +13,13 @@ module.exports = function createTempFile(params) {
 
 	writeStream.path = path
 
-	streamEnd(writeStream, function (err) {
-		streamHasEnded = true
-	})
-
 	writeStream.cleanup = function cln(cb) {
-		if (!streamHasEnded) writeStream.end()
+		writeStream.end()
 		fs.unlink(path, cb || function() {})
 	}
 
 	writeStream.cleanupSync = function clnSnc() {
-		if (!streamHasEnded) writeStream.end()
+		writeStream.end()
 		try {
 			fs.unlinkSync(path)
 		} catch (err) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var fs = require('fs')
-var streamEnd = require('end-of-stream')
 var generateTempFilePath = require('tempfile2')
 
 module.exports = function createTempFile(params) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function createTempFile(params) {
 
 	writeStream.cleanup = function cln(cb) {
 		if (!streamHasEnded) writeStream.end()
-		fs.unlink(path, cb || emitError)
+		fs.unlink(path, cb || function() {})
 	}
 
 	writeStream.cleanupSync = function clnSnc() {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "create-temp-file",
-  "version": "0.3.1",
   "description": "Creates a temporary file, returns a write stream, a path, and cleanup functions",
+  "homepage": "https://github.com/ArtskydJ/create-temp-file",
+  "version": "0.3.1",
   "main": "index.js",
-  "scripts": {
-    "test": "tap test/*.js"
-  },
+  "author": "Joseph Dykstra",
   "repository": {
     "type": "git",
     "url": "https://github.com/ArtskydJ/create-temp-file"
+  },
+  "bugs": {
+    "url": "https://github.com/ArtskydJ/create-temp-file/issues"
   },
   "keywords": [
     "stream",
@@ -16,17 +18,14 @@
     "tmp",
     "write"
   ],
-  "author": "Joseph Dykstra",
-  "license": "VOL",
-  "bugs": {
-    "url": "https://github.com/ArtskydJ/create-temp-file/issues"
+  "dependencies": {
+    "tempfile2": "^1.0.0"
   },
-  "homepage": "https://github.com/ArtskydJ/create-temp-file",
   "devDependencies": {
     "tap": "^1.0.10"
   },
-  "dependencies": {
-    "end-of-stream": "~1.1.0",
-    "tempfile2": "^1.0.0"
-  }
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "license": "VOL"
 }


### PR DESCRIPTION
Improvements:
- end of stream dependency is not necessary because If you call `.end` two times, it does not throw an error.
- avoid emitError if callback is not provided in async mode, because `fs.unlink` does not throw an error if the callback is not provided, so no sense to throw an error now.

In addition:
- `package.json` keys formatted using [finepack](https://travis-ci.org/Kikobeats/finepack).
- created a `.bumpedrc` file using [bumped](https://github.com/bumped/bumped).
